### PR TITLE
Update HyperSerialEsp8266_SK6812NeutralWhite.ino

### DIFF
--- a/version for SK6812 neutral white/HyperSerialEsp8266_SK6812NeutralWhite/HyperSerialEsp8266_SK6812NeutralWhite.ino
+++ b/version for SK6812 neutral white/HyperSerialEsp8266_SK6812NeutralWhite/HyperSerialEsp8266_SK6812NeutralWhite.ino
@@ -5,7 +5,7 @@
 
 #define   THIS_IS_RGBW             // RGBW SK6812, otherwise comment it
 bool      skipFirstLed = true;     // if set the first led in the strip will be set to black (for level shifters)
-int       serialSpeed = 2000000;   // serial port speed
+const unsigned long       serialSpeed = 2000000;   // serial port speed
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////            CONFIG SECTION ENDS               /////////////////////////////


### PR DESCRIPTION
Change serialSpeed from "int" to "const unsigned long"
A const, because it is a constant that is not going to be changed later on in the code.
A unsigned long, because the maximum value a int can hold, is a number between -32768 and 32767. (unsigned long is between 0 and 4,294,967,295)