### PR TITLE
Refactor HyperSerialEsp

### DIFF
--- a/version for Neopixels (SK6812 WS2812)/HyperSerialEsp8266_Neopixel/HyperSerialEsp8266_Neopixel.ino
+++ b/version for Neopixels (SK6812 WS2812)/HyperSerialEsp8266_Neopixel/HyperSerialEsp8266_Neopixel.ino
@@ -1,411 +1,624 @@
+// MIT License
+// Copyright (c) 2022 awawa-dev, Lord-Grey
+
 #include <NeoPixelBus.h>
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////          CONFIG SECTION STARTS               /////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#define THIS_IS_RGBW	   // RGBW SK6812, otherwise comment it
-#define COLD_WHITE		   // for RGBW (THIS_IS_RGBW enabled) select COLD version, comment it if NEUTRAL
-bool skipFirstLed = false; // if set the first led in the strip will be set to black (for level shifters using sacrifice LED)
-int serialSpeed = 2000000; // serial port speed
+#define THIS_IS_RGBW                  // RGBW SK6812, otherwise comment it
+#define COLD_WHITE                    // for RGBW (THIS_IS_RGBW enabled) select COLD version, comment it if NEUTRAL
 
+const bool skipFirstLed = false;      // if set the first led in the strip will be set to black (for level shifters using sacrifice LED)
+const int serialSpeed = 2000000;      // serial port speed
+
+const bool reportStats = true;        // Send back processing statistics
+const int  reportStatInterval_s = 1; // Send back processing every interval in seconds
+
+/* Statistics breakdown:
+    FPS: Updates to the LEDs per second
+    F-FPS: Frames identified per second
+    S:  Shown (Done) updates to the LEDs per given interval
+    F:  Frames identified per interval (garbled grames cannot be counted)
+    G:  Good frames identified per interval
+    B:  Total bad frames of all types identified per interval
+    BF: Bad frames identified per interval
+    BS: Skipped  incomplete frames
+    BC: Frames failing CRC check per interval
+    BFL Frames failing Fletcher content validation per interval
+*/ 
+
+//Developer configs
+#define ENABLE_STRIP
+#define ENABLE_CHECK_FLETCHER
+
+const int SERIAL_SIZE_RX = 2048;
+
+#ifndef ENABLE_STRIP
+const int serial1Speed = 460800;
+const bool reportInput = false;
+#endif
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////            CONFIG SECTION ENDS               /////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+const String version = "7.1";
+
 #ifdef THIS_IS_RGBW
-	float whiteLimit = 1.0f;
-	#ifdef COLD_WHITE
-		uint8_t rCorrection = 0xA0; // adjust red   -> white in 0-0xFF range
-		uint8_t gCorrection = 0xA0; // adjust green -> white in 0-0xFF range
-		uint8_t bCorrection = 0xA0; // adjust blue  -> white in 0-0xFF range
-	#else
-		uint8_t rCorrection = 0xB0; // adjust red   -> white in 0-0xFF range
-		uint8_t gCorrection = 0xB0; // adjust green -> white in 0-0xFF range
-		uint8_t bCorrection = 0x70; // adjust blue  -> white in 0-0xFF range
-	#endif
+float whiteLimit = 1.0f;
+#ifdef COLD_WHITE
+uint8_t rCorrection = 0xA0; // adjust red   -> white in 0-0xFF range
+uint8_t gCorrection = 0xA0; // adjust green -> white in 0-0xFF range
+uint8_t bCorrection = 0xA0; // adjust blue  -> white in 0-0xFF range
+#else
+uint8_t rCorrection = 0xB0; // adjust red   -> white in 0-0xFF range
+uint8_t gCorrection = 0xB0; // adjust green -> white in 0-0xFF range
+uint8_t bCorrection = 0x70; // adjust blue  -> white in 0-0xFF range
+#endif
 #endif
 
+int ledCount = 0;   // This is dynamic, don't change it
 int pixelCount = 0; // This is dynamic, don't change it
 
 #ifdef THIS_IS_RGBW
-	#define LED_TYPE NeoGrbwFeature
+#define LED_TYPE NeoGrbwFeature
 #else
-	#define LED_TYPE NeoGrbFeature
+#define LED_TYPE NeoGrbFeature
 #endif
 
-NeoPixelBus<LED_TYPE, NeoEsp8266Uart1800KbpsMethod> *strip = NULL;
+uint8_t* ledBuffer;
+int ledBufferSize;
 
-void Init(int count)
-{
-	if (strip != NULL)
-		delete strip;
-
-	pixelCount = count;
-	strip = new NeoPixelBus<LED_TYPE, NeoEsp8266Uart1800KbpsMethod>(pixelCount);
-	strip->Begin();
-}
+#ifdef ENABLE_STRIP
+NeoPixelBus<LED_TYPE, NeoEsp8266Uart1800KbpsMethod>* strip = NULL;
+#endif
 
 enum class AwaProtocol
 {
-	HEADER_A,
-	HEADER_w,
-	HEADER_a,
-	HEADER_HI,
-	HEADER_LO,
-	HEADER_CRC,
-	VERSION2_GAIN,
-	VERSION2_RED,
-	VERSION2_GREEN,
-	VERSION2_BLUE,
-	RED,
-	GREEN,
-	BLUE,
-	FLETCHER1,
-	FLETCHER2
+  HEADER_A,
+  HEADER_w,
+  HEADER_a,
+  HEADER_HI,
+  HEADER_LO,
+  HEADER_CRC,
+  CHANNELCALIB_GAIN,
+  CHANNELCALIB_RED,
+  CHANNELCALIB_GREEN,
+  CHANNELCALIB_BLUE,
+  PIXEL,
+  FLETCHER1,
+  FLETCHER2
 };
 
-// static data buffer for the loop
-#define MAX_BUFFER 2048
-uint8_t buffer[MAX_BUFFER];
 AwaProtocol state = AwaProtocol::HEADER_A;
-bool version2 = false;
-uint8_t incoming_gain = 0;
-uint8_t incoming_red = 0;
-uint8_t incoming_green = 0;
-uint8_t incoming_blue = 0;
+
+const int headerSize = 6;
+const int trailerSize = 2;
+const int calibInfoSize = 4;
+int bytesRead = 0;
+
+bool isVersion2 = false;
+bool isChannelCalib = false;
 uint8_t CRC = 0;
-uint16_t count = 0;
-uint16_t currentPixel = 0;
+int count = 0;
+int currentPixel = 0;
 uint16_t fletcher1 = 0;
 uint16_t fletcher2 = 0;
 
 #ifdef THIS_IS_RGBW
-	RgbwColor inputColor;
-	uint8_t wChannel[256];
-	uint8_t rChannel[256];
-	uint8_t gChannel[256];
-	uint8_t bChannel[256];
+RgbwColor inputColor;
+uint8_t wChannel[256];
+uint8_t rChannel[256];
+uint8_t gChannel[256];
+uint8_t bChannel[256];
 #else
-	RgbColor inputColor;
+RgbColor inputColor;
 #endif
 
-// stats
+bool ledsComplete = false;
+
+// statistics
+const int reportStatInterval_ms = reportStatInterval_s * 1000;
+unsigned long curTime;
 unsigned long stat_start = 0;
-uint16_t stat_good = 0;
+uint16_t stat_shown = 0;
 uint16_t stat_frames = 0;
-uint16_t stat_final_good = 0;
+uint16_t stat_good = 0;
+uint16_t stat_bad = 0;
+
+uint16_t stat_bad_frame = 0;
+uint16_t stat_bad_skip = 0;
+uint16_t stat_bad_crc = 0;
+uint16_t stat_bad_fletcher = 0;
+
+uint16_t stat_final_shown = 0;
 uint16_t stat_final_frames = 0;
-bool wantShow = false;
+uint16_t stat_final_good = 0;
+uint16_t stat_final_bad = 0;
 
-inline void ShowMe()
+uint16_t stat_final_bad_frame = 0;
+uint16_t stat_final_bad_skip = 0;
+uint16_t stat_final_bad_crc = 0;
+uint16_t stat_final_bad_fletcher = 0;
+
+//Debugging
+String inputString;
+String inputErrorString;
+String debugString;
+
+void printStringHex(String string)
 {
-	if (wantShow == true && strip != NULL && strip->CanShow())
-	{
-		stat_good++;
-		wantShow = false;
-		strip->Show();
-	}
-}
+#ifndef ENABLE_STRIP
+  Serial1.println(string.length());
+  for (int i = 0; i < string.length(); ++i)
+  {
+    if (i % 36 == 0)
+    {
+      Serial1.println();
+      Serial1.print("[");
+      Serial1.print(i);
+      Serial1.print("] ");
+    }
 
-void readSerialData()
-{
-	unsigned long curTime = millis();
-	uint16_t bufferPointer = 0;
-	uint16_t internalIndex = min(Serial.available(), MAX_BUFFER);
-
-	if (internalIndex > 0)
-		internalIndex = Serial.readBytes(buffer, internalIndex);
-
-	// stats
-	if (internalIndex > 0 && curTime - stat_start > 1000)
-	{
-		if (stat_frames > 0 && stat_frames >= stat_good)
-		{
-			stat_final_good = stat_good;
-			stat_final_frames = stat_frames;
-		}
-
-		stat_start = curTime;
-		stat_good = 0;
-		stat_frames = 0;
-	}
-	else if (curTime - stat_start > 5000)
-	{
-		stat_start = curTime;
-		stat_good = 0;
-		stat_frames = 0;
-
-		Serial.write("HyperSerialEsp8266 version 6.\r\nStatistics for the last full 1 second cycle.\r\n");
-		Serial.write("Frames per second: ");
-		Serial.print(stat_final_frames);
-		Serial.write("\r\nGood frames: ");
-		Serial.print(stat_final_good);
-		Serial.write("\r\nBad frames:  ");
-		Serial.print(stat_final_frames - stat_final_good);
-		Serial.write("\r\n-------------------------\r\n");
-	}
-
-	if (state == AwaProtocol::HEADER_A)
-		ShowMe();
-
-	while (bufferPointer < internalIndex)
-	{
-		byte input = buffer[bufferPointer++];
-		switch (state)
-		{
-		case AwaProtocol::HEADER_A:
-			version2 = false;
-			if (input == 'A')
-				state = AwaProtocol::HEADER_w;
-			break;
-
-		case AwaProtocol::HEADER_w:
-			if (input == 'w')
-				state = AwaProtocol::HEADER_a;
-			else
-				state = AwaProtocol::HEADER_A;
-			break;
-
-		case AwaProtocol::HEADER_a:
-			if (input == 'a')
-				state = AwaProtocol::HEADER_HI;
-			else if (input == 'A')
-			{
-				state = AwaProtocol::HEADER_HI;
-				version2 = true;
-			}
-			else
-				state = AwaProtocol::HEADER_A;
-			break;
-
-		case AwaProtocol::HEADER_HI:
-			stat_frames++;
-			currentPixel = 0;
-			count = input * 0x100;
-			CRC = input;
-			fletcher1 = 0;
-			fletcher2 = 0;
-			state = AwaProtocol::HEADER_LO;
-			break;
-
-		case AwaProtocol::HEADER_LO:
-			count += input;
-			CRC = CRC ^ input ^ 0x55;
-			state = AwaProtocol::HEADER_CRC;
-			break;
-
-		case AwaProtocol::HEADER_CRC:
-			if (CRC == input)
-			{
-				if (count + 1 != pixelCount)
-					Init(count + 1);
-				
-				state = AwaProtocol::RED;
-			}
-			else
-				state = AwaProtocol::HEADER_A;
-			break;
-
-		case AwaProtocol::RED:
-			inputColor.R = input;
-			fletcher1 = (fletcher1 + (uint16_t)input) % 255;
-			fletcher2 = (fletcher2 + fletcher1) % 255;
-
-			state = AwaProtocol::GREEN;
-			break;
-
-		case AwaProtocol::GREEN:
-			inputColor.G = input;
-			fletcher1 = (fletcher1 + (uint16_t)input) % 255;
-			fletcher2 = (fletcher2 + fletcher1) % 255;
-
-			state = AwaProtocol::BLUE;
-			break;
-
-		case AwaProtocol::BLUE:
-			inputColor.B = input;
-
-			#ifdef THIS_IS_RGBW
-				inputColor.W = min(rChannel[inputColor.R],
-								min(gChannel[inputColor.G],
-									bChannel[inputColor.B]));
-				inputColor.R -= rChannel[inputColor.W];
-				inputColor.G -= gChannel[inputColor.W];
-				inputColor.B -= bChannel[inputColor.W];
-				inputColor.W = wChannel[inputColor.W];
-			#endif
-
-			fletcher1 = (fletcher1 + (uint16_t)input) % 255;
-			fletcher2 = (fletcher2 + fletcher1) % 255;
-
-			if (currentPixel == 0 && skipFirstLed)
-			{
-				#ifdef THIS_IS_RGBW
-					strip->SetPixelColor(currentPixel++, RgbwColor(0, 0, 0, 0));
-				#else
-					strip->SetPixelColor(currentPixel++, RgbColor(0, 0, 0));
-				#endif
-			}
-			else
-				setStripPixel(currentPixel++, inputColor);
-
-			if (count-- > 0)
-				state = AwaProtocol::RED;
-			else
-			{
-				if (version2)
-					state = AwaProtocol::VERSION2_GAIN;
-				else
-					state = AwaProtocol::FLETCHER1;
-			}
-
-			break;
-			
-		case AwaProtocol::VERSION2_GAIN:
-			incoming_gain = input;
-			fletcher1 = (fletcher1 + (uint16_t)input) % 255;
-			fletcher2 = (fletcher2 + fletcher1) % 255;
-
-			state = AwaProtocol::VERSION2_RED;
-			break;
-
-		case AwaProtocol::VERSION2_RED:
-			incoming_red = input;
-			fletcher1 = (fletcher1 + (uint16_t)input) % 255;
-			fletcher2 = (fletcher2 + fletcher1) % 255;
-
-			state = AwaProtocol::VERSION2_GREEN;
-			break;
-
-		case AwaProtocol::VERSION2_GREEN:
-			incoming_green = input;
-			fletcher1 = (fletcher1 + (uint16_t)input) % 255;
-			fletcher2 = (fletcher2 + fletcher1) % 255;
-
-			state = AwaProtocol::VERSION2_BLUE;
-			break;
-
-		case AwaProtocol::VERSION2_BLUE:
-			incoming_blue = input;
-			fletcher1 = (fletcher1 + (uint16_t)input) % 255;
-			fletcher2 = (fletcher2 + fletcher1) % 255;
-
-			state = AwaProtocol::FLETCHER1;
-			break;
-
-		case AwaProtocol::FLETCHER1:
-			if (input != fletcher1)
-				state = AwaProtocol::HEADER_A;
-			else
-				state = AwaProtocol::FLETCHER2;
-			break;
-
-		case AwaProtocol::FLETCHER2:
-			if (input == fletcher2)
-			{
-				wantShow = true;
-				ShowMe();
-			
-
-				if (version2)
-				{
-					#ifdef THIS_IS_RGBW
-						float final_limit = (incoming_gain != 255) ? incoming_gain / 255.0f : 1.0f;
-						if (rCorrection != incoming_red || gCorrection != incoming_green || bCorrection != incoming_blue || whiteLimit != final_limit)
-						{
-							rCorrection = incoming_red;
-							gCorrection = incoming_green;
-							bCorrection = incoming_blue;
-							whiteLimit = final_limit;
-							prepareCalibration();
-						}
-					#endif
-				}
-			}
-
-			state = AwaProtocol::HEADER_A;
-			break;
-		}
-	}
-}
-
-#ifdef THIS_IS_RGBW
-	inline void setStripPixel(uint16_t pix, RgbwColor &inputColor)
-	{
-		if (pix < pixelCount)
-		{
-			strip->SetPixelColor(pix, inputColor);
-		}
-	}
-#else
-	inline void setStripPixel(uint16_t pix, RgbColor &inputColor)
-	{
-		if (pix < pixelCount)
-		{
-			strip->SetPixelColor(pix, inputColor);
-		}
-	}
+    if (string[i] < 16)
+      Serial1.print("0");
+    Serial1.print(string[i], HEX);
+    Serial1.print(":");
+  }
 #endif
+}
+
+inline void showMe()
+{
+#ifdef ENABLE_STRIP
+  if (strip != NULL && strip->CanShow())
+  {
+    stat_shown++;
+    strip->Show();
+  }
+#endif
+}
+
+// statistics
+inline void showStats()
+{
+  if (reportStats)
+  {
+    if (stat_frames > 0)
+    {
+      stat_final_shown = stat_shown;
+      stat_final_frames = stat_frames;
+      stat_final_good = stat_good;
+      stat_final_bad = stat_bad;
+
+      stat_final_bad_frame = stat_bad_frame;
+      stat_final_bad_skip = stat_bad_skip;
+      stat_final_bad_crc = stat_bad_crc;
+      stat_final_bad_fletcher = stat_bad_fletcher;
+    }
+
+    stat_start = curTime;
+    stat_shown = 0;
+    stat_frames = 0;
+    stat_good = 0;
+    stat_bad = 0;
+
+    stat_bad_frame = 0;
+    stat_bad_skip = 0;
+    stat_bad_crc = 0;
+    stat_bad_fletcher = 0;
+
+    String summary = String("FPS: ") + (stat_final_shown / reportStatInterval_s) +
+      " F-FPS: " + (stat_final_frames / reportStatInterval_s) +
+      " S: " + stat_final_shown +
+      " F: " + stat_final_frames +
+      " G: " + stat_final_good +
+      " B: " + stat_final_bad +
+      " (BF: " + stat_final_bad_frame +
+      " BS: " + stat_final_bad_skip +
+      " BC: " + stat_final_bad_crc +
+      " BFL: " + stat_final_bad_fletcher +
+      ")";
+#ifdef ENABLE_STRIP
+    Serial.println(summary);
+#else
+    Serial1.println(summary);
+#endif
+  }
+}
+
+void InitLeds(uint16_t ledCount, int pixelCount, bool channelCalibration = false)
+{
+  if (ledBuffer != NULL)
+    delete ledBuffer;
+
+  ledBufferSize = pixelCount + (channelCalibration ? calibInfoSize : 0);
+  ledBuffer = new uint8_t[ledBufferSize];
+
+#ifdef ENABLE_STRIP
+  if (strip != NULL)
+    delete strip;
+
+  strip = new NeoPixelBus<LED_TYPE, NeoEsp8266Uart1800KbpsMethod>(ledCount);
+  strip->Begin();
+#endif
+}
+
+inline void processSerialData()
+{
+  while (Serial.available()) {
+
+    char input = Serial.read();
+    ++bytesRead;
+
+#ifndef ENABLE_STRIP
+    if (reportInput)
+      inputString += input;
+#endif
+
+    switch (state)
+    {
+    case AwaProtocol::HEADER_A:
+      if (input == 'A')
+      {
+        state = AwaProtocol::HEADER_w;
+      }
+      break;
+
+    case AwaProtocol::HEADER_w:
+      if (input == 'w')
+        state = AwaProtocol::HEADER_a;
+      else
+      {
+        state = AwaProtocol::HEADER_A;
+      }
+      break;
+
+    case AwaProtocol::HEADER_a:
+      if (input == 'a')
+      {
+        isVersion2 = false;
+        state = AwaProtocol::HEADER_HI;
+      }
+      else if (input == 'A')
+      {
+        state = AwaProtocol::HEADER_HI;
+        isVersion2 = true;
+      }
+      else
+      {
+        state = AwaProtocol::HEADER_A;
+      }
+      break;
+
+    case AwaProtocol::HEADER_HI:
+
+      stat_frames++;
+
+      count = input << 8;
+
+      CRC = input;
+      fletcher1 = 0;
+      fletcher2 = 0;
+      state = AwaProtocol::HEADER_LO;
+      break;
+
+    case AwaProtocol::HEADER_LO:
+      count += input + 1;
+
+      if (ledCount != count || isChannelCalib != isVersion2)
+      {
+        ledCount = count;
+        isChannelCalib = isVersion2;
+        pixelCount = ledCount * 3;
+
+        if (isChannelCalib)
+          prepareCalibration();
+
+        InitLeds(ledCount, pixelCount, isChannelCalib);
+      }
+
+      CRC = CRC ^ input ^ 0x55;
+
+      state = AwaProtocol::HEADER_CRC;
+
+      break;
+
+    case AwaProtocol::HEADER_CRC:
+
+      // Check, if incomplete package information was skipped, set bytesread to headersize and skip wrong input
+      if (bytesRead != headerSize)
+      {
+        stat_bad_skip++;
+        bytesRead = headerSize;
+      }
+
+      currentPixel = 0;
+      if (CRC == input)
+      {
+        state = AwaProtocol::PIXEL;
+      }
+      else
+      {
+        // CRC failure
+        stat_bad++;
+        stat_bad_crc++;
+
+        state = AwaProtocol::HEADER_A;
+      }
+      break;
+
+    case AwaProtocol::PIXEL:
+      ledBuffer[currentPixel++] = input;
+      if (currentPixel == pixelCount)
+      {
+        if (isChannelCalib)
+          state = AwaProtocol::CHANNELCALIB_GAIN;
+        else
+          state = AwaProtocol::FLETCHER1;
+      }
+      break;
+
+    case AwaProtocol::CHANNELCALIB_GAIN:
+      ledBuffer[currentPixel++] = input;
+      state = AwaProtocol::CHANNELCALIB_RED;
+      break;
+
+    case AwaProtocol::CHANNELCALIB_RED:
+      ledBuffer[currentPixel++] = input;
+
+      state = AwaProtocol::CHANNELCALIB_GREEN;
+      break;
+
+    case AwaProtocol::CHANNELCALIB_GREEN:
+      ledBuffer[currentPixel++] = input;
+
+      state = AwaProtocol::CHANNELCALIB_BLUE;
+      break;
+
+    case AwaProtocol::CHANNELCALIB_BLUE:
+      ledBuffer[currentPixel++] = input;
+
+      state = AwaProtocol::FLETCHER1;
+      break;
+
+    case AwaProtocol::FLETCHER1:
+      fletcher1 = input;
+
+      state = AwaProtocol::FLETCHER2;
+      break;
+
+    case AwaProtocol::FLETCHER2:
+      fletcher2 = input;
+      ledsComplete = true;
+
+      state = AwaProtocol::HEADER_A;
+      break;
+    }
+  }
+}
 
 void setup()
 {
-	// Init serial port
-	Serial.begin(serialSpeed);
-	Serial.setTimeout(50);
-	Serial.setRxBufferSize(2048);
+  // Init serial port
+  Serial.begin(serialSpeed);
+  int bufSize = Serial.setRxBufferSize(SERIAL_SIZE_RX);
+  Serial.setTimeout(50);
 
-	// Display config
-	Serial.write("\r\nWelcome!\r\nAwa driver 6.\r\n");
+#ifndef ENABLE_STRIP
+  Serial1.begin(serial1Speed);
+#endif
 
-	// first LED info
-	if (skipFirstLed)
-		Serial.write("First LED: disabled\r\n");
-	else
-		Serial.write("First LED: enabled\r\n");
+  // Display config
+  Serial.println();
+  Serial.println("Welcome!");
+  Serial.println("Awa driver " + version);
 
-	// RGBW claibration info
-	#ifdef THIS_IS_RGBW
-		#ifdef COLD_WHITE
-			Serial.write("Default color mode: RGBW cold\r\n");
-		#else
-			Serial.write("Default color mode: RGBW neutral\r\n");
-		#endif
-		prepareCalibration();
-	#else
-		Serial.write("Color mode: RGB\r\n");
-	#endif
+  // first LED info
+  if (skipFirstLed)
+    Serial.println("First LED: disabled");
+  else
+    Serial.println("First LED: enabled");
+
+  // RGBW claibration info
+#ifdef THIS_IS_RGBW
+#ifdef COLD_WHITE
+  Serial.println("Default color mode: RGBW cold");
+#else
+  Serial.println("Default color mode: RGBW neutral");
+#endif
+  prepareCalibration();
+#else
+  Serial.println("Color mode: RGB");
+#endif
+
+  InitLeds(ledCount, pixelCount);
 }
 
 void prepareCalibration()
 {
-	#ifdef THIS_IS_RGBW
-		// prepare LUT calibration table, cold white is much better than "neutral" white
-		for (uint32_t i = 0; i < 256; i++)
-		{
-			// color calibration
-			float red = rCorrection * i;   // adjust red
-			float green = gCorrection * i; // adjust green
-			float blue = bCorrection * i;  // adjust blue
+#ifdef THIS_IS_RGBW
+  // prepare LUT calibration table, cold white is much better than "neutral" white
+  for (uint32_t i = 0; i < 256; i++)
+  {
+    // color calibration
+    float red = rCorrection * i;   // adjust red
+    float green = gCorrection * i; // adjust green
+    float blue = bCorrection * i;  // adjust blue
 
-			wChannel[i] = (uint8_t)round(min(whiteLimit * i, 255.0f));
-			rChannel[i] = (uint8_t)round(min(red / 0xFF, 255.0f));
-			gChannel[i] = (uint8_t)round(min(green / 0xFF, 255.0f));
-			bChannel[i] = (uint8_t)round(min(blue / 0xFF, 255.0f));
-		}
+    wChannel[i] = (uint8_t)round(min(whiteLimit * i, 255.0f));
+    rChannel[i] = (uint8_t)round(min(red / 0xFF, 255.0f));
+    gChannel[i] = (uint8_t)round(min(green / 0xFF, 255.0f));
+    bChannel[i] = (uint8_t)round(min(blue / 0xFF, 255.0f));
+  }
 
-		Serial.write("RGBW calibration. White limit(%): ");
-		Serial.print(whiteLimit * 100.0f);
-		Serial.write(" %, red: ");
-		Serial.print(rCorrection);
-		Serial.write(" , green: ");
-		Serial.print(gCorrection);
-		Serial.write(" , blue: ");
-		Serial.print(bCorrection);
-		Serial.write("\r\n");
-	#endif
+  Serial.write("RGBW calibration. White limit(%): ");
+  Serial.print(whiteLimit * 100.0f);
+  Serial.write(" %, red: ");
+  Serial.print(rCorrection);
+  Serial.write(" , green: ");
+  Serial.print(gCorrection);
+  Serial.write(" , blue: ");
+  Serial.print(bCorrection);
+  Serial.println();
+#endif
 }
 
 void loop()
 {
-	readSerialData();
+  curTime = millis();
+
+#ifdef __AVR__
+  // nothing , USART Interrupt is implemented
+  ESPserialEvent();
+#else
+  // ESP8266  polling
+  ESPserialEvent();
+#endif
+
+  if (ledsComplete)
+  {
+#ifndef ENABLE_STRIP
+    if (reportInput)
+    {
+      Serial1.println();
+      Serial1.print("<input> L: ");
+      printStringHex(inputString);
+      Serial1.println("<\input>");
+      inputString = "";
+
+      Serial1.print("bytesRead: ");
+      Serial1.print(bytesRead);
+      Serial1.print(" , currentPixel: ");
+      Serial1.print(currentPixel);
+      Serial1.print(" ,pixelCount: ");
+      Serial1.print(pixelCount);
+      Serial1.println();
+    }
+#endif
+
+    int frameSize = headerSize + ledBufferSize + trailerSize;
+
+    if (bytesRead > frameSize)
+    {
+      //Add number of frames ignored on top of frame
+      int frames = bytesRead / frameSize;
+      stat_frames += frames;
+
+      //Count frame plus frames ignored as bad frames
+      int badFrames = frames + 1;
+      stat_bad += badFrames;
+      stat_bad_frame += badFrames;
+    }
+    else
+    {
+
+#ifdef ENABLE_CHECK_FLETCHER
+      //Test if content is valid
+      uint16_t item = 0;
+      uint16_t fletch1 = 0;
+      uint16_t fletch2 = 0;
+
+      while (item < ledBufferSize)
+      {
+        fletch1 = (fletch1 + (uint16_t)ledBuffer[item]) % 255;
+        fletch2 = (fletch2 + fletch1) % 255;
+        ++item;
+      }
+      if ((fletch1 == fletcher1) && (fletch2 == fletcher2))
+      {
+#endif
+        stat_good++;
+
+        uint16_t startLed = 0;
+        if (skipFirstLed)
+        {
+#ifdef ENABLE_STRIP
+          #ifdef THIS_IS_RGBW
+          strip->SetPixelColor(startLed, RgbwColor(0, 0, 0, 0));
+          #else
+          strip->SetPixelColor(startLed, RgbColor(0, 0, 0));
+          #endif
+#endif
+          startLed = 1;
+        }
+
+        for (uint16_t led = startLed; led < ledCount; ++led)
+        {
+          inputColor.R = ledBuffer[led * 3];
+          inputColor.G = ledBuffer[led * 3 + 1];
+          inputColor.B = ledBuffer[led * 3 + 2];
+
+          #ifdef THIS_IS_RGBW
+          inputColor.W = min(rChannel[inputColor.R],
+            min(gChannel[inputColor.G],
+              bChannel[inputColor.B]));
+          inputColor.R -= rChannel[inputColor.W];
+          inputColor.G -= gChannel[inputColor.W];
+          inputColor.B -= bChannel[inputColor.W];
+          inputColor.W = wChannel[inputColor.W];
+          #endif
+#ifdef ENABLE_STRIP
+          strip->SetPixelColor(led, inputColor);
+#endif
+        }
+
+        showMe();
+        yield();
+
+        #ifdef THIS_IS_RGBW
+        if (isChannelCalib)
+        {
+          uint8_t incoming_gain = ledBuffer[pixelCount];
+          uint8_t incoming_red = ledBuffer[pixelCount + 1];
+          uint8_t incoming_green = ledBuffer[pixelCount + 2];
+          uint8_t incoming_blue = ledBuffer[pixelCount + 3];
+
+          float final_limit = (incoming_gain != 255) ? incoming_gain / 255.0f : 1.0f;
+          if (rCorrection != incoming_red || gCorrection != incoming_green || bCorrection != incoming_blue || whiteLimit != final_limit)
+          {
+            rCorrection = incoming_red;
+            gCorrection = incoming_green;
+            bCorrection = incoming_blue;
+            whiteLimit = final_limit;
+            prepareCalibration();
+          }
+        }
+        #endif
+
+#ifdef ENABLE_CHECK_FLETCHER
+      }
+      else
+      {
+        stat_bad++;
+        stat_bad_fletcher++;
+      }
+#endif
+    }
+
+    bytesRead = 0;
+    state = AwaProtocol::HEADER_A;
+
+    ledsComplete = false;
+  }
+
+  if ((curTime - stat_start > reportStatInterval_ms))
+  {
+    if (stat_frames > 0)
+    {
+      showStats();
+    }
+  }
 }
+
+#ifdef __AVR__
+void serialEvent()
+{
+  processSerialData();
+}
+#elif defined(ARDUINO_ARCH_ESP8266) ||  defined(ARDUINO_ARCH_ESP32)
+void ESPserialEvent()
+{
+  processSerialData();
+}
+#endif


### PR DESCRIPTION
## Refactor HyperSerialEsp8266
(@asturel might share additional feedback on improved user experience)

### Changes

- Split serial processing from content validation and LED updates
- Move to non-blocking serial functions
- Do Flechter calculations/validation only for a frame and not the "garbage" before frames, i.e. incomplete frames

- Enable/Disable statistics and define reporting interval allows exploring a good balance between fps and error rate
- Have statistics as a one-liner to show it in the HyperHDR/Hyperion log as one record
(corresponding backed code [Serial LED-Devices - Support device feedback, show statistics provided](https://github.com/Lord-Grey/hyperion.ng/commit/b1491085895db955a5d3f1661b31ff91493b42fb)
- More granular statistics breakdown, showing the different bad frame scenarios
    FPS: Updates to the LEDs per second
    F-FPS: Frames identified per second
    S:  Shown (Done) updates to the LEDs per given interval
    F:  Frames identified per interval (garbled grames cannot be counted)
    G:  Good frames identified per interval
    B:  Total bad frames of all types identified per interval
    BF: Bad frames identified per interval
    BS: Skipped  incomplete frames
    BC: Frames failing CRC check per interval
    BFL Frames failing Fletcher content validation per interval

- Allow to test serial processing without strip processing (undefine ENABLE_STRIP) using 2nd serial

### Fixes
- Consider disabling calibration when update package changes from calibration to non-calibration (A?A -> A?a)

### PS
Other sketches can be provided when PR is accepted


### Sample Statistics
200 LEDs, Feed 50Hz, ESP8266 for illustration

![image](https://user-images.githubusercontent.com/48840279/200390918-5e29439f-8923-4673-a893-15b5c753bf12.png)
