### PR TITLE
Clear LEDs

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,11 +1,12 @@
 ; You can adjust speed of the serial port communication by adjusting 'SERIALCOM_SPEED' variable in [env] section
+; Also you can force to clear LEDs on the esp8266 start up (-DCLEAR_LEDS=number_of_leds_to_clear)
 ; The pinout can not be changed for esp8266 board
 
 [platformio]
 default_envs = SK6812_RGBW_COLD, SK6812_RGBW_NEUTRAL, WS281x_RGB, SPI_APA102_SK9822_HD107, SPI_WS2801
 
 [env]
-build_flags = -DSERIALCOM_SPEED=2000000
+build_flags = -DSERIALCOM_SPEED=2000000 ;-DCLEAR_LEDS=24 ;remove leading semi-colon to uncomment
 extra_scripts = pre:extra_script.py
 platform = espressif8266
 board = d1_mini

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,9 @@
 #define _XSTR2(x,y) _STR(x) _STR(y)
 #define VAR_NAME_VALUE2(var) #var " = " _XSTR2(var)
 
+#ifdef CLEAR_LEDS
+	#pragma message(VAR_NAME_VALUE(CLEAR_LEDS))
+#endif
 #ifdef NEOPIXEL_RGBW
 	#pragma message(VAR_NAME_VALUE(NEOPIXEL_RGBW))
 #endif
@@ -76,6 +79,18 @@ void setup()
 	Serial.setRxBufferSize(MAX_BUFFER);
 	Serial.begin(SERIALCOM_SPEED);
 	while (!Serial) continue;
+
+#ifdef CLEAR_LEDS
+	LED_DRIVER* _ledStrip = new LED_DRIVER(CLEAR_LEDS);
+	ColorDefinition _black(0);
+	_ledStrip->Begin();
+	for(int i = 0; i < CLEAR_LEDS; i++)
+		_ledStrip->SetPixelColor(i, _black);
+	_ledStrip->Dirty();
+	_ledStrip->Show(false);
+	delay(10);
+	delete _ledStrip;
+#endif
 
 	// Display config
 	Serial.println(HELLO_MESSAGE);


### PR DESCRIPTION
Added option to clear LEDs during esp8266 startup when electrical noise may turn on some LEDs. `-DCLEAR_LEDS=number_of_leds_to_clear` in the platform.ini config file.
Removes phantom lights caused by electric noise when HyperHDR is not currently running and the LED strip cannot be controlled. Use only the number that is necessary to remove them, not necessarily the total number in the LED strip.