### PR TITLE
Add direct 32-bit rendering for RGBW with dithering

### DIFF
--- a/include/calibration.h
+++ b/include/calibration.h
@@ -28,7 +28,7 @@
 #ifdef NEOPIXEL_RGBW
 	typedef RgbwColor ColorDefinition;
 #elif defined(SPILED_APA102)
-	typedef DotStarColor ColorDefinition;	
+	typedef RgbwColor ColorDefinition;	
 #else
 	typedef RgbColor ColorDefinition;
 #endif

--- a/include/calibration.h
+++ b/include/calibration.h
@@ -27,6 +27,8 @@
 
 #ifdef NEOPIXEL_RGBW
 	typedef RgbwColor ColorDefinition;
+#elif defined(SPILED_APA102)
+	typedef DotStarColor ColorDefinition;	
 #else
 	typedef RgbColor ColorDefinition;
 #endif

--- a/include/framestate.h
+++ b/include/framestate.h
@@ -35,6 +35,7 @@
 enum class AwaProtocol
 {
 	HEADER_A,
+	HEADER_W,
 	HEADER_w,
 	HEADER_a,
 	HEADER_HI,
@@ -47,6 +48,7 @@ enum class AwaProtocol
 	RED,
 	GREEN,
 	BLUE,
+	EXTRA_COLOR_BYTE_4,
 	FLETCHER1,
 	FLETCHER2
 };
@@ -59,6 +61,7 @@ class
 {
 	AwaProtocol state = AwaProtocol::HEADER_A;
 	bool protocolVersion2 = false;
+	bool protocolVersion3 = false;
 	uint8_t CRC = 0;
 	uint16_t count = 0;
 	uint16_t currentLed = 0;
@@ -151,6 +154,27 @@ class
 		inline bool isProtocolVersion2()
 		{
 			return protocolVersion2;
+		}
+
+		/**
+		 * @brief Set if frame protocol version 3 (direct 32bit mode)
+		 *
+		 * @param newVer
+		 */
+		inline void setProtocolVersion3(bool newVer)
+		{
+			protocolVersion3 = newVer;
+		}
+
+		/**
+		 * @brief Verify if frame protocol version 3 (direct 32bit mode)
+		 *
+		 * @return true
+		 * @return false
+		 */
+		inline bool isProtocolVersion3() const
+		{
+			return protocolVersion3;
 		}
 
 		/**

--- a/include/main.h
+++ b/include/main.h
@@ -29,7 +29,7 @@
 #define MAIN_H
 
 #define MAX_BUFFER 5120
-#define HELLO_MESSAGE "\r\nWelcome!\r\nAwa driver 8."
+#define HELLO_MESSAGE "\r\nWelcome!\r\nAwa driver 11."
 
 #include "calibration.h"
 #include "statistics.h"
@@ -86,6 +86,7 @@ void processData()
 		case AwaProtocol::HEADER_A:
 			// assume it's protocol version 1, verify it later
 			frameState.setProtocolVersion2(false);
+			frameState.setProtocolVersion3(false);
 			if (input == 'A')
 				frameState.setState(AwaProtocol::HEADER_w);
 			break;
@@ -93,6 +94,20 @@ void processData()
 		case AwaProtocol::HEADER_w:
 			if (input == 'w')
 				frameState.setState(AwaProtocol::HEADER_a);
+#if defined(NEOPIXEL_RGBW) || defined(SPILED_APA102)
+			else if (input == 'W')
+				frameState.setState(AwaProtocol::HEADER_W);
+#endif
+			else
+				frameState.setState(AwaProtocol::HEADER_A);
+			break;
+		case AwaProtocol::HEADER_W:
+			// detect protocol version 3
+			if (input == 'a')			
+			{
+				frameState.setState(AwaProtocol::HEADER_HI);
+				frameState.setProtocolVersion3(true);
+			}
 			else
 				frameState.setState(AwaProtocol::HEADER_A);
 			break;
@@ -169,9 +184,37 @@ void processData()
 			frameState.setState(AwaProtocol::BLUE);
 			break;
 
+		case AwaProtocol::EXTRA_COLOR_BYTE_4:
+			#ifdef NEOPIXEL_RGBW
+				frameState.color.W = input;
+			#elif defined(SPILED_APA102)
+				frameState.color.Brightness = input;
+			#endif
+			frameState.addFletcher(input);
+
+			if (base.setStripPixel(frameState.getCurrentLedIndex(), frameState.color))
+			{
+				frameState.setState(AwaProtocol::RED);
+			}
+			else
+			{
+				frameState.setState(AwaProtocol::FLETCHER1);
+			}
+			break;
+
 		case AwaProtocol::BLUE:
 			frameState.color.B = input;
 			frameState.addFletcher(input);
+
+			if (frameState.isProtocolVersion3())
+			{
+				frameState.setState(AwaProtocol::EXTRA_COLOR_BYTE_4);
+				break;
+			}
+
+			#if defined(SPILED_APA102)
+				frameState.color.Brightness = 0xFF;
+			#endif
 
 			#ifdef NEOPIXEL_RGBW
 				// calculate RGBW from RGB using provided calibration data

--- a/include/main.h
+++ b/include/main.h
@@ -188,7 +188,7 @@ void processData()
 			#ifdef NEOPIXEL_RGBW
 				frameState.color.W = input;
 			#elif defined(SPILED_APA102)
-				frameState.color.Brightness = input;
+				frameState.color.W = input;
 			#endif
 			frameState.addFletcher(input);
 
@@ -213,7 +213,7 @@ void processData()
 			}
 
 			#if defined(SPILED_APA102)
-				frameState.color.Brightness = 0xFF;
+				frameState.color.W = 0xFF;
 			#endif
 
 			#ifdef NEOPIXEL_RGBW

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,7 +63,7 @@
 #elif NEOPIXEL_RGB
 	#define LED_DRIVER NeoPixelBus<NeoGrbFeature, NeoEsp8266Uart1Ws2812xMethod>
 #elif SPILED_APA102
-	#define LED_DRIVER NeoPixelBus<DotStarBgrFeature, DotStarSpiMethod>
+	#define LED_DRIVER NeoPixelBus<DotStarLbgrFeature, DotStarSpiMethod>
 #elif SPILED_WS2801
 	#define LED_DRIVER NeoPixelBus<NeoRbgFeature, NeoWs2801Spi2MhzMethod>
 #endif


### PR DESCRIPTION
Introduced direct 32-bit mode for the upcoming RGBW mode with dithering, powered by the Infinite Color Engine in HyperHDR.
More: https://github.com/awawa-dev/HyperHDR/wiki/ICE_RGBW